### PR TITLE
Fixed ScrapeRequest for Facebook

### DIFF
--- a/lib/social_net/facebook/api/scrape_request.rb
+++ b/lib/social_net/facebook/api/scrape_request.rb
@@ -3,6 +3,7 @@ require 'social_net/facebook/errors/unknown_video'
 require 'active_support'
 require 'active_support/core_ext'
 require 'nokogiri'
+require 'net/http'
 
 module SocialNet
   module Facebook
@@ -51,7 +52,7 @@ module SocialNet
             video['id'] = @video_id
             video['video_url'] = data.at("meta[property='og:url']")['content']
             video['link'] = m[1]
-            video['caption'] = data.at("meta[property='og:description']")['content']
+            video['caption'] = data.at("meta[name='description']")['content']
             video['thumbnail_url'] = data.at("meta[property='og:image']")['content']
           end
         end
@@ -70,3 +71,9 @@ module SocialNet
     end
   end
 end
+
+# https://www.facebook.com/TimHowellADVENTURE/videos/1280907158777599/?v=1280907158777599
+
+s = SocialNet::Facebook::Api::ScrapeRequest.new attrs={username: 'TimHowellADVENTURE', video_id: '1280907158777599'}
+
+s.run

--- a/lib/social_net/facebook/api/scrape_request.rb
+++ b/lib/social_net/facebook/api/scrape_request.rb
@@ -71,9 +71,3 @@ module SocialNet
     end
   end
 end
-
-# https://www.facebook.com/TimHowellADVENTURE/videos/1280907158777599/?v=1280907158777599
-
-s = SocialNet::Facebook::Api::ScrapeRequest.new attrs={username: 'TimHowellADVENTURE', video_id: '1280907158777599'}
-
-s.run


### PR DESCRIPTION
There is no more og:description meta field present in the data. Replaced it with description to fix video caption